### PR TITLE
T3 Field Engineers Rework

### DIFF
--- a/units/BrewLAN/SAL0319/SAL0319_unit.bp
+++ b/units/BrewLAN/SAL0319/SAL0319_unit.bp
@@ -23,16 +23,16 @@ UnitBlueprint {
         'OVERLAYOMNI',
         'OVERLAYMISC',
     },
-	
+
     CollisionOffsetY = -0.25,
-	
+
     Defense = {
         ArmorType = 'Normal',
         EconomyThreatLevel = 93,
         Health = 1380,
         MaxHealth = 1380,
         RegenRate = 1,
-		
+
         Shield = {
             ImpactEffects = 'AeonShieldHit01',
             ImpactMesh = '/effects/entities/ShieldSection01/ShieldSection01_mesh',
@@ -50,9 +50,9 @@ UnitBlueprint {
         },
 
     },
-	
+
     Description = '<LOC sal0209_desc>Defence Engineer',
-	
+
     Display = {
         Abilities = {
             '<LOC ability_engineeringsuite>Engineering Suite',
@@ -63,34 +63,34 @@ UnitBlueprint {
             '<LOC ability_sacrifice>Sacrifice',
         },
     },
-	
+
     Economy = {
         BuildCostEnergy = 7260,
         BuildCostMass = 950,
         BuildRate = 17,
         BuildTime = 4500,
-		
+
         BuildableCategory = {
             'BUILTBYTIER3ENGINEER DEFENSE AEON',
             'BUILTBYTIER3ENGINEER INDIRECTFIRE AEON',
             'BUILTBYTIER3ENGINEER NUKE SILO AEON',
             'BUILTBYTIER3FIELD AEON',
         },
-		
+
         SacrificeEnergyMult = 0.9,
         SacrificeMassMult = 0.9,
-		
+
         MaintenanceConsumptionPerSecondEnergy = 24,
 		MaxBuildDistance = 5.5,
-		
+
         StorageEnergy = 300,
         StorageMass = 20,
     },
-	
-	
+
+
     Intel = {
 		FreeIntel = true,
-        
+
         RadarStealth = true,
 
         OmniRadius = 6,
@@ -98,15 +98,15 @@ UnitBlueprint {
         VisionRadius = 24,
         WaterVisionRadius = 20,
     },
-	
+
     Interface = {
         HelpText = '<LOC sal0209_desc>Defence Engineer',
     },
-	
+
     LifeBarHeight = 0.075,
     LifeBarOffset = 0.45,
     LifeBarSize = 1.1,
-	
+
     Physics = {
         BackUpDistance = 4,
         BankingSlope = 0.5,
@@ -115,10 +115,10 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         Elevation = 0.5,
-        MaxAcceleration = 2.5,
+        MaxAcceleration = 4.6,
         MaxBrake = 5.6,
         MaxSpeed = 5.6,
-        MaxSpeedReverse = 0,
+        MaxSpeedReverse = 4.6,
         MaxSteerForce = 1000,
 
         MeshExtentsX = 1.1,
@@ -133,8 +133,8 @@ UnitBlueprint {
         RotateOnSpotThreshold = 0.1,
 
         TurnFacingRate = 100,
-        TurnRadius = 0,
-        TurnRate = 90,
+        TurnRadius = 2,
+        TurnRate = 120,
     },
-		
+
 }

--- a/units/BrewLAN/SAL0319/SAL0319_unit.bp
+++ b/units/BrewLAN/SAL0319/SAL0319_unit.bp
@@ -41,7 +41,7 @@ UnitBlueprint {
             PassOverkillDamage = true,
             RegenAssistMult = 60,
             ShieldEnergyDrainRechargeTime = 5,
-            ShieldMaxHealth = 600,
+            ShieldMaxHealth = 7250,
             ShieldRechargeTime = 15,
             ShieldRegenRate = 40,
             ShieldRegenStartTime = 1,
@@ -115,9 +115,9 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         Elevation = 0.5,
-        MaxAcceleration = 2,
-        MaxBrake = 2.6,
-        MaxSpeed = 2.6,
+        MaxAcceleration = 2.5,
+        MaxBrake = 5.6,
+        MaxSpeed = 5.6,
         MaxSpeedReverse = 0,
         MaxSteerForce = 1000,
 
@@ -134,7 +134,7 @@ UnitBlueprint {
 
         TurnFacingRate = 100,
         TurnRadius = 0,
-        TurnRate = 50,
+        TurnRate = 90,
     },
 		
 }

--- a/units/BrewLAN/SAL0319/SAL0319_unit.bp
+++ b/units/BrewLAN/SAL0319/SAL0319_unit.bp
@@ -1,0 +1,140 @@
+UnitBlueprint {
+    Merge = true,
+    BlueprintId = "sal0319",
+
+    Categories = {
+        'SELECTABLE',
+        'BUILTBYLANDTIER3FACTORY',
+        'AEON',
+        'MOBILE',
+        'LAND',
+        'TECH3',
+        'CONSTRUCTION',
+        'ENGINEER',
+        'FIELDENGINEER',
+        'REPAIR',
+        'RECLAIM',
+        'CAPTURE',
+        'HOVER',
+        'VISIBLETORECON',
+        'RECLAIMABLE',
+        'PATROLHELPER',
+        'SHOWQUEUE',
+        'OVERLAYOMNI',
+        'OVERLAYMISC',
+    },
+	
+    CollisionOffsetY = -0.25,
+	
+    Defense = {
+        ArmorType = 'Normal',
+        EconomyThreatLevel = 93,
+        Health = 1380,
+        MaxHealth = 1380,
+        RegenRate = 1,
+		
+        Shield = {
+            ImpactEffects = 'AeonShieldHit01',
+            ImpactMesh = '/effects/entities/ShieldSection01/ShieldSection01_mesh',
+            Mesh = '/effects/entities/AeonShield01/AeonShield01_mesh',
+            MeshZ = '/effects/entities/Shield01/Shield01z_mesh',
+            PassOverkillDamage = true,
+            RegenAssistMult = 60,
+            ShieldEnergyDrainRechargeTime = 5,
+            ShieldMaxHealth = 600,
+            ShieldRechargeTime = 15,
+            ShieldRegenRate = 40,
+            ShieldRegenStartTime = 1,
+            ShieldSize = 1.2,
+            ShieldVerticalOffset = -.1,
+        },
+
+    },
+	
+    Description = '<LOC sal0209_desc>Defence Engineer',
+	
+    Display = {
+        Abilities = {
+            '<LOC ability_engineeringsuite>Engineering Suite',
+            '<LOC ability_hover>Hover',
+            '<LOC ability_personalshield>Personal Shield',
+            '<LOC ability_personalstealth>Personal Stealth',
+            '<LOC ability_radar>Radar',
+            '<LOC ability_sacrifice>Sacrifice',
+        },
+    },
+	
+    Economy = {
+        BuildCostEnergy = 7260,
+        BuildCostMass = 950,
+        BuildRate = 17,
+        BuildTime = 4500,
+		
+        BuildableCategory = {
+            'BUILTBYTIER3ENGINEER DEFENSE AEON',
+            'BUILTBYTIER3ENGINEER INDIRECTFIRE AEON',
+            'BUILTBYTIER3ENGINEER NUKE SILO AEON',
+            'BUILTBYTIER3FIELD AEON',
+        },
+		
+        SacrificeEnergyMult = 0.9,
+        SacrificeMassMult = 0.9,
+		
+        MaintenanceConsumptionPerSecondEnergy = 24,
+		MaxBuildDistance = 5.5,
+		
+        StorageEnergy = 300,
+        StorageMass = 20,
+    },
+	
+	
+    Intel = {
+		FreeIntel = true,
+        
+        RadarStealth = true,
+
+        OmniRadius = 6,
+        RadarRadius = 48,
+        VisionRadius = 24,
+        WaterVisionRadius = 20,
+    },
+	
+    Interface = {
+        HelpText = '<LOC sal0209_desc>Defence Engineer',
+    },
+	
+    LifeBarHeight = 0.075,
+    LifeBarOffset = 0.45,
+    LifeBarSize = 1.1,
+	
+    Physics = {
+        BackUpDistance = 4,
+        BankingSlope = 0.5,
+        BuildOnLayerCaps = {
+            LAYER_Land = true,
+        },
+        DragCoefficient = 0.2,
+        Elevation = 0.5,
+        MaxAcceleration = 2,
+        MaxBrake = 2.6,
+        MaxSpeed = 2.6,
+        MaxSpeedReverse = 0,
+        MaxSteerForce = 1000,
+
+        MeshExtentsX = 1.1,
+        MeshExtentsY = 0.65,
+        MeshExtentsZ = 1.1,
+
+        MinSpeedPercent = 0,
+        MotionType = 'RULEUMT_Hover',
+
+        RotateBodyWhileMoving = true,
+        RotateOnSpot = true,
+        RotateOnSpotThreshold = 0.1,
+
+        TurnFacingRate = 100,
+        TurnRadius = 0,
+        TurnRate = 50,
+    },
+		
+}

--- a/units/BrewLAN/SEL0319/SEL0319_unit.bp
+++ b/units/BrewLAN/SEL0319/SEL0319_unit.bp
@@ -121,5 +121,3 @@ UnitBlueprint {
     },
 	
 }
-
-

--- a/units/BrewLAN/SEL0319/SEL0319_unit.bp
+++ b/units/BrewLAN/SEL0319/SEL0319_unit.bp
@@ -7,7 +7,7 @@ UnitBlueprint {
         EconomyThreatLevel = 93,
         Health = 3800,
         MaxHealth = 3800,
-        RegenRate = 50,
+        RegenRate = 15,
 		SurfaceThreatLevel = 6,
     },
 
@@ -121,4 +121,5 @@ UnitBlueprint {
     },
 	
 }
+
 

--- a/units/BrewLAN/SEL0319/SEL0319_unit.bp
+++ b/units/BrewLAN/SEL0319/SEL0319_unit.bp
@@ -1,0 +1,121 @@
+UnitBlueprint {
+    Merge = true,
+    BlueprintId = "sel0319",
+
+    Defense = {
+        ArmorType = 'Normal',
+        EconomyThreatLevel = 93,
+        Health = 1380,
+        MaxHealth = 1380,
+        RegenRate = 1,
+		SurfaceThreatLevel = 6,
+    },
+
+    Intel = {
+        JamRadius = {
+            Max = 12,
+            Min = 12,
+        },
+        JammerBlips = 5,
+
+		OmniRadius = 8,
+        RadarRadius = 48,
+        VisionRadius = 28,
+		WaterVisionRadius = 28,
+    },
+
+    Physics = {
+        BackUpDistance = 4,
+        BankingSlope = 0,
+        BuildOnLayerCaps = {
+            LAYER_Land = true,
+            LAYER_Water = true,
+        },
+        DragCoefficient = 0.2,
+        MaxAcceleration = 3,
+        MaxBrake = 3,
+        MaxSpeed = 3,
+        MaxSpeedReverse = 1,
+        MaxSteerForce = 15,
+        MeshExtentsX = 0.75,
+        MeshExtentsY = 1.2,
+        MeshExtentsZ = 0.75,
+        MinSpeedPercent = 0,
+        MotionType = 'RULEUMT_AmphibiousFloating',
+        TurnRadius = 0,
+        TurnRate = 120,
+    },
+	
+    Weapon = {
+        {
+            AboveWaterTargetsOnly = true,
+            
+            Audio = {
+                Fire = Sound { Bank = 'XEL_Weapons', Cue = 'XEL0209_Riot_Gun', LodCutoff = 'Weapon_LodCutoff'},
+            },
+            
+            BallisticArc = 'RULEUBA_LowArc',
+            CollideFriendly = false,
+			
+            Damage = 30,
+            DamageType = 'Normal',
+			
+            DisplayName = 'Hells Fury Riot Gun',
+			
+            FireTargetLayerCapsTable = {
+                Land = 'Land|Water|Seabed',
+                Water = 'Land|Water|Seabed',
+            },
+            FiringTolerance = 2,
+			
+            Label = 'Riotgun01',
+			
+            MaxRadius = 24,
+
+            MuzzleVelocity = 28,
+			
+            ProjectileId = '/projectiles/TDFRiot03/TDFRiot03_proj.bp',
+            ProjectileLifetime = 1,
+
+            RackBones = {
+                {
+                    MuzzleBones = {'Gun_Muzzle'},
+                    RackBone = 'Gun_Turret',
+                },
+            },
+
+            RangeCategory = 'UWRC_DirectFire',
+			
+            RateOfFire = 2,		-- 60 DPS
+			
+            SlavedToBody = false,
+
+            TargetPriorities = {
+                "SPECIALHIGHPRI",
+                "TECH3 MOBILE",
+                "TECH2 MOBILE",
+                "TECH1 MOBILE",
+                "(STRUCTURE * DEFENSE - ANTIMISSILE)",
+                "ALLUNITS",
+            },
+            TargetRestrictDisallow = 'UNTARGETABLE,WALL',
+
+			
+            TurretBoneMuzzle = 'Gun_Muzzle',
+            TurretBonePitch = 'Gun_Barrel',
+            TurretBoneYaw = 'Gun_Turret',
+            TurretDualManipulators = false,
+			
+            TurretPitch = 10,
+            TurretPitchRange = 40,
+            TurretPitchSpeed = 180,
+			
+            TurretYaw = 0,
+            TurretYawRange = 360,
+            TurretYawSpeed = 180,
+			
+            Turreted = true,
+        },
+    },
+	
+}

--- a/units/BrewLAN/SEL0319/SEL0319_unit.bp
+++ b/units/BrewLAN/SEL0319/SEL0319_unit.bp
@@ -5,9 +5,9 @@ UnitBlueprint {
     Defense = {
         ArmorType = 'Normal',
         EconomyThreatLevel = 93,
-        Health = 1380,
-        MaxHealth = 1380,
-        RegenRate = 1,
+        Health = 3800,
+        MaxHealth = 3800,
+        RegenRate = 50,
 		SurfaceThreatLevel = 6,
     },
 
@@ -29,6 +29,8 @@ UnitBlueprint {
         BankingSlope = 0,
         BuildOnLayerCaps = {
             LAYER_Land = true,
+            LAYER_Seabed = true,
+            LAYER_Sub = true,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,
@@ -41,7 +43,7 @@ UnitBlueprint {
         MeshExtentsY = 1.2,
         MeshExtentsZ = 0.75,
         MinSpeedPercent = 0,
-        MotionType = 'RULEUMT_AmphibiousFloating',
+        MotionType = 'RULEUMT_Amphibious',
         TurnRadius = 0,
         TurnRate = 120,
     },
@@ -119,3 +121,4 @@ UnitBlueprint {
     },
 	
 }
+

--- a/units/BrewLAN/SRL0319/SRL0319_unit.bp
+++ b/units/BrewLAN/SRL0319/SRL0319_unit.bp
@@ -5,9 +5,9 @@ UnitBlueprint {
     Defense = {
         ArmorType = 'Normal',
 
-        Health = 1380,
-        MaxHealth = 1380,
-        RegenRate = 3,
+        Health = 2800,
+        MaxHealth = 2800,
+        RegenRate = 125,
 
         EconomyThreatLevel = 93,
         SurfaceThreatLevel = 5,
@@ -19,6 +19,8 @@ UnitBlueprint {
         BankingSlope = 0,
         BuildOnLayerCaps = {
             LAYER_Land = true,
+            LAYER_Seabed = true,
+            LAYER_Sub = true,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,
@@ -108,3 +110,4 @@ UnitBlueprint {
     },
 
 }
+

--- a/units/BrewLAN/SRL0319/SRL0319_unit.bp
+++ b/units/BrewLAN/SRL0319/SRL0319_unit.bp
@@ -1,0 +1,110 @@
+UnitBlueprint {
+    Merge = true,
+    BlueprintId = "srl0319",
+
+    Defense = {
+        ArmorType = 'Normal',
+
+        Health = 1380,
+        MaxHealth = 1380,
+        RegenRate = 3,
+
+        EconomyThreatLevel = 93,
+        SurfaceThreatLevel = 5,
+		
+    },
+	
+    Physics = {
+        BackUpDistance = 4,
+        BankingSlope = 0,
+        BuildOnLayerCaps = {
+            LAYER_Land = true,
+            LAYER_Water = true,
+        },
+        DragCoefficient = 0.2,
+        MaxAcceleration = 3,
+        MaxBrake = 3,
+        MaxSpeed = 3,
+        MaxSpeedReverse = 16,
+        MaxSteerForce = 15,
+        MinSpeedPercent = 0,
+        MotionType = 'RULEUMT_Amphibious',
+        TurnRadius = 0,
+        TurnRate = 120,
+    },
+
+    Weapon = {
+        {
+            AboveWaterTargetsOnly = true,
+            Audio = {
+                Fire = Sound { Bank = 'URLWeapon', Cue = 'URL0203_Bolter', LodCutoff = 'Weapon_LodCutoff' },
+            },
+            
+            BallisticArc = 'RULEUBA_LowArc',
+            CollideFriendly = false,
+			
+            Damage = 25,
+			DamageRadius = 0,
+            DamageType = 'Normal',
+			
+            DisplayName = 'Electron Bolter',
+			
+            FireTargetLayerCapsTable = {
+                Land = 'Land|Water|Seabed',
+                Water = 'Land|Water|Seabed',
+            },
+            FiringTolerance = 2,
+			
+            Label = 'Bolter',
+            LeadTarget = true,
+			
+            MaxRadius = 22,
+			
+            MuzzleSalvoDelay = 0.3,
+            MuzzleSalvoSize = 2,
+            MuzzleVelocity = 38,
+			
+            ProjectileId = '/projectiles/CDFBolter02/CDFBolter02_proj.bp',
+            ProjectileLifetime = 0.7,
+
+            RackBones = {
+                {
+                    MuzzleBones = {'Turret01_Muzzle','Turret02_Muzzle'},
+                    RackBone = 'Turret01_Barrel',
+                },
+            },
+			
+            RangeCategory = 'UWRC_DirectFire',
+			
+            RateOfFire = 0.5,	-- 50 DPS
+
+			
+            TargetPriorities = {
+                "SPECIALHIGHPRI",
+                "TECH3 MOBILE",
+                "TECH2 MOBILE",
+                "TECH1 MOBILE",
+                "(STRUCTURE * DEFENSE - ANTIMISSILE)",
+                "ALLUNITS",
+            },
+            TargetRestrictDisallow = 'UNTARGETABLE,WALL',
+
+			
+            TurretBoneMuzzle = 'Turret01_Muzzle',
+            TurretBonePitch = 'Turret01_Barrel',
+            TurretBoneYaw = 'Turret01_Barrel',
+            TurretDualManipulators = false,
+			
+            TurretPitch = 5,
+            TurretPitchRange = 40,
+            TurretPitchSpeed = 30,
+			
+            TurretYaw = 0,
+            TurretYawRange = 180,
+            TurretYawSpeed = 90,
+			
+            Turreted = true,
+        },
+    },
+
+}

--- a/units/BrewLAN/SRL0319/SRL0319_unit.bp
+++ b/units/BrewLAN/SRL0319/SRL0319_unit.bp
@@ -110,5 +110,3 @@ UnitBlueprint {
     },
 
 }
-
-

--- a/units/BrewLAN/SRL0319/SRL0319_unit.bp
+++ b/units/BrewLAN/SRL0319/SRL0319_unit.bp
@@ -7,7 +7,7 @@ UnitBlueprint {
 
         Health = 2800,
         MaxHealth = 2800,
-        RegenRate = 125,
+        RegenRate = 75,
 
         EconomyThreatLevel = 93,
         SurfaceThreatLevel = 5,
@@ -110,4 +110,5 @@ UnitBlueprint {
     },
 
 }
+
 

--- a/units/BrewLAN/SSL0319/SSL0319_unit.bp
+++ b/units/BrewLAN/SSL0319/SSL0319_unit.bp
@@ -5,8 +5,8 @@ UnitBlueprint {
     Defense = {
         ArmorType = 'Normal',
         EconomyThreatLevel = 93,
-        Health = 1380,
-        MaxHealth = 1380,
+        Health = 4750,
+        MaxHealth = 4750,
         RegenRate = 1,
     },
 
@@ -116,3 +116,4 @@ UnitBlueprint {
     },
 
 }
+

--- a/units/BrewLAN/SSL0319/SSL0319_unit.bp
+++ b/units/BrewLAN/SSL0319/SSL0319_unit.bp
@@ -1,0 +1,118 @@
+UnitBlueprint {
+    Merge = true,
+	BlueprintId = "ssl0319",
+
+    Defense = {
+        ArmorType = 'Normal',
+        EconomyThreatLevel = 93,
+        Health = 1380,
+        MaxHealth = 1380,
+        RegenRate = 1,
+    },
+
+    Physics = {
+        BankingSlope = 0,
+        BuildOnLayerCaps = {
+            LAYER_Land = true,
+            LAYER_Seabed = true,
+            LAYER_Sub = true,
+            LAYER_Water = true,
+        },
+        DragCoefficient = 0.2,
+        MaxAcceleration = 3,
+        MaxBrake = 3,
+        MaxSpeed = 3,
+        MaxSpeedReverse = 1,
+        MaxSteerForce = 10,
+        MeshExtentsX = 1,
+        MeshExtentsY = 0.5,
+        MeshExtentsZ = 1,
+        MinSpeedPercent = 0,
+        MotionType = 'RULEUMT_Amphibious',
+        RotateOnSpot = true,
+        RotateOnSpotThreshold = 0.1,
+        TurnRadius = 0,
+        TurnRate = 90,
+    },
+
+    Weapon = {
+        {
+            AboveWaterTargetsOnly = true,
+            Audio = {
+                Fire = Sound { Bank = 'XSL_Weapon', Cue = 'XSL0201_Cannon_Spectra', LodCutoff = 'Weapon_LodCutoff'},
+            },
+
+            BallisticArc = 'RULEUBA_LowArc',
+            CollideFriendly = false,
+			
+            Damage = 40,
+            DamageRadius = 0,
+            DamageType = 'Normal',
+			
+            DisplayName = 'Oh Spectra Cannon',
+			
+            FireTargetLayerCapsTable = {
+                Land = 'Land|Water|Seabed',
+                Water = 'Land|Water|Seabed',
+            },
+			
+            FiringTolerance = 2,
+			
+            Label = 'MainGun',
+			
+            MaxRadius = 20,
+
+            MuzzleVelocity = 25,
+			
+            ProjectileId = '/projectiles/SDFOhCannon01/SDFOhCannon01_proj.bp',
+            ProjectileLifetime = 1,
+
+            RackBones = {
+                {
+                    MuzzleBones = {'Turret_Barrel_Muzzle'},
+                    RackBone = 'Turret_Barrel',
+                },
+                {
+                    MuzzleBones = {'Turret_Barrel_Muzzle001'},
+                    RackBone = 'Turret_Barrel001',
+                },
+            },
+
+            RackRecoilDistance = -1,
+			
+            RangeCategory = 'UWRC_DirectFire',
+			
+            RateOfFire = 1.5,	-- 60 DPS
+
+			
+            TargetPriorities = {
+                "SPECIALHIGHPRI",
+                "TECH3 MOBILE",
+                "TECH2 MOBILE",
+                "TECH1 MOBILE",
+                "(STRUCTURE * DEFENSE - ANTIMISSILE)",
+                "ALLUNITS",
+            },
+            TargetRestrictDisallow = 'UNTARGETABLE,WALL',
+
+			
+            TurretBoneMuzzle = 'Turret_Barrel_Muzzle',
+            TurretBonePitch = 'Turret_Barrel',
+            TurretBoneYaw = 'Turret',
+            TurretBoneDualMuzzle = 'Turret_Barrel_Muzzle001',
+            TurretBoneDualPitch = 'Turret_Barrel001',
+            TurretDualManipulators = true,
+			
+            TurretPitch = 0,
+            TurretPitchRange = 30,
+            TurretPitchSpeed = 60,
+			
+            TurretYaw = 0,
+            TurretYawRange = 180,
+            TurretYawSpeed = 100,
+			
+            Turreted = true,
+        },
+    },
+
+}


### PR DESCRIPTION
*Field engineers have always been a bit out of the game. Having lower health than regular engineers feels ridiculous; trading the T1 gun for the inability to build economic structures is quite pointless. No one ever uses them. This type of unit should either be removed or buffed in some way.*

*I suggest a major survivability buff to increase their value in tense reclaim wars at battlefield hotspots. Additionally, most engineers should have their amphibious motion type changed to "Amphibious" (seabed) instead of "Hover" (floating). The reasoning is to make SACU reclaiming in naval warfare less OP by giving field engineers a similar niche.* 
 
**Seraphim T3 Field Engineer "Iyazyne"**
* Health 1380 -> 4750

**Cybran T3 Field Engineer "House"**
* Health 1380 -> 2800
* Regen 3 -> 125

**UEF T3 Field Engineer "Custodian"**
* Health 1380 -> 3800
* Regen 1 -> 15

**Aeon T3 Defense Engineer "Bilmon"**
* Shield Health 600 -> 7250
* Speed 2.6 -> 5.6

*Aeon is unique here because I can’t make hover units go to the seabed. I believe I’ve given this unit a very specific niche: a super-healthy, fast reclaimer. This compensates for the Harbinger not having the reclaim ability it has in vanilla.* 